### PR TITLE
Make template depend on can-view-import and can-stache-bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
   },
   "dependencies": {
     "can-stache": "^3.0.0-pre.1",
+    "can-stache-bindings": "^3.0.0-pre.4",
+    "can-view-import": "^3.0.0-pre.2",
     "jquery": "~2.2.1"
   },
   "devDependencies": {

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -22,8 +22,23 @@ function translate(load) {
 
 	var intermediateAndImports = getIntermediateAndImports(load.source);
 
+	var commonDependencies = Promise.all([
+		this.normalize("can-view-import", module.id),
+		this.normalize("can-stache-bindings", module.id)
+	]);
+
+
 	// Add bundle configuration for these dynamic imports
-	return addBundles(intermediateAndImports.dynamicImports, load.name).then(function(){
+	return Promise.all([
+		addBundles(intermediateAndImports.dynamicImports, load.name),
+		commonDependencies
+	]).then(function(results){
+		var imports = results[1];
+
+		// In add in the common dependencies of every stache file
+		intermediateAndImports.imports.unshift.apply(
+			intermediateAndImports.imports, imports
+		);
 
 		intermediateAndImports.imports.unshift("can-stache/src/mustache_core");
 		intermediateAndImports.imports.unshift("can-stache");
@@ -31,7 +46,6 @@ function translate(load) {
 
 		return template(intermediateAndImports.imports,
 										intermediateAndImports.intermediate);
-
 	});
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var template = require('./template.stache!');
 var nodeLists = require("can-view-nodelist");
 var stache = require("can-stache");
 var QUnit = require("steal-qunit");
+var loader = require("@loader");
 
 QUnit.module("steal-stache");
 
@@ -12,4 +13,19 @@ QUnit.test("node-lists work", function(){
 	});
 
 	template({}, {}, nl);
+});
+
+QUnit.test("can-import works", function(){
+	stop();
+	loader["import"]("test/tests/foo.stache")
+	.then(function(template){
+		var frag = template();
+
+		setTimeout(function(){
+			var span = frag.firstChild.nextSibling.nextSibling;
+			equal(span.firstChild.nodeValue, "works", "imported bar and used it");
+
+			start();
+		},5);
+	});
 });

--- a/test/tests/bar.js
+++ b/test/tests/bar.js
@@ -1,0 +1,1 @@
+module.exports = "works";

--- a/test/tests/foo.stache
+++ b/test/tests/foo.stache
@@ -1,0 +1,2 @@
+<can-import from="test/tests/bar" {^value}="*bar" />
+<span>{{*bar}}</span>


### PR DESCRIPTION
This makes all templates depend on these two modules. This way you can
do normal stuff like binding to elements and importing other things.
