### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "can-stache": "^3.0.13",
     "can-stache-bindings": "^3.0.5",
     "can-view-import": "^3.0.3",
-    "jquery": "~3.1.1"
+    "jquery": "2.x - 3.x"
   },
   "devDependencies": {
     "can-view-nodelist": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -51,22 +51,22 @@
     }
   },
   "dependencies": {
-    "can-stache": "^3.0.0-pre.1",
-    "can-stache-bindings": "^3.0.0-pre.4",
-    "can-view-import": "^3.0.0-pre.2",
-    "jquery": "~2.2.1"
+    "can-stache": "^3.0.13",
+    "can-stache-bindings": "^3.0.5",
+    "can-view-import": "^3.0.3",
+    "jquery": "~3.1.1"
   },
   "devDependencies": {
-    "can-view-nodelist": "^3.0.0-pre.1",
+    "can-view-nodelist": "^3.0.2",
     "bit-docs": "0.0.7",
-    "done-serve": "^0.2.0",
-    "donejs-cli": "^0.9.4",
-    "generator-donejs": "^0.9.0",
-    "jshint": "^2.9.1",
-    "steal": "^0.16.0",
-    "steal-qunit": "^0.1.1",
-    "steal-tools": "^0.16.0",
-    "testee": "^0.2.4"
+    "done-serve": "^0.2.5",
+    "donejs-cli": "^0.9.5",
+    "generator-donejs": "^0.9.6",
+    "jshint": "^2.9.4",
+    "steal": "^0.16.43",
+    "steal-qunit": "^0.1.4",
+    "steal-tools": "^0.16.8",
+    "testee": "^0.3.0"
   },
   "bit-docs": {
     "dependencies": {


### PR DESCRIPTION
Simple dependency update courtesy of [npm-check-updates](https://www.npmjs.com/package/npm-check-updates)

The only major upgrade is jQuery 3.1.1