### PR TITLE
Remove canjs pre-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     }
   },
   "dependencies": {
-    "can-stache": "^3.1.0-pre.4",
-    "can-stache-bindings": "^3.2.0-pre.1",
-    "can-view-import": "^3.1.0-pre.0",
+    "can-stache": "^3.1.0",
+    "can-stache-bindings": "^3.2.0",
+    "can-view-import": "^3.1.0",
     "jquery": "2.x - 3.x"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "can-view-nodelist": "^3.1.0-pre.0",
+    "can-view-nodelist": "^3.1.0",
     "done-serve": "^0.2.5",
     "donejs-cli": "^0.9.5",
     "generator-donejs": "^0.9.6",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.githubusercontent.com/phillipskevin/75a3626b00dd32709b13132706cb7f30/raw/a98a16c838c21cdecd0a30898e98ba2cd74eaa2f/remove-pre-release-deps.js**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.