### PR TITLE
Don’t create a new options scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     }
   },
   "dependencies": {
-    "can-stache": "^4.0.0-pre.14",
-    "can-stache-bindings": "^4.0.0-pre.13",
-    "can-view-import": "^4.0.0-pre.2",
+    "can-stache": "^4.0.0-pre.21",
+    "can-stache-bindings": "^4.0.0-pre.16",
+    "can-view-import": "^4.0.0-pre.3",
     "jquery": "2.x - 3.x"
   },
   "devDependencies": {

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -12,11 +12,8 @@ function template(imports, intermediate, filename){
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
 		"\treturn function(scope, options, nodeList){\n" +
-		"\t\tvar moduleOptions = { module: module };\n" +
-		"\t\tif(!(options instanceof mustacheCore.Options)) {\n" +
-		"\t\t\toptions = new mustacheCore.Options(options || {});\n" +
-		"\t\t}\n" +
-		"\t\treturn renderer(scope, options.add(moduleOptions), nodeList);\n" +
+		"\t\tvar moduleOptions = Object.assign( { module: module }, options );\n" +
+		"\t\treturn renderer(scope, moduleOptions, nodeList);\n" +
 		"\t};\n" +
 	"});";
 }


### PR DESCRIPTION
It doesn’t exist in 4.0: https://github.com/canjs/can-stache/pull/389

The tests fail as of this commit because they require a change to can-view-import