### PR TITLE
Add improved error messaging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,15 +46,17 @@
   },
   "dependencies": {
     "can-stache": "^4.0.0",
+    "can-stache-ast": "^1.0.0",
     "can-stache-bindings": "^4.0.0",
-    "can-view-import": "^4.0.0"
+    "can-view-import": "^4.0.0",
+    "steal-config-utils": "^1.0.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
     "can-test-helpers": "^1.1.0",
     "can-view-nodelist": "^4.0.0",
     "jshint": "^2.9.4",
-    "steal": "^1.5.11",
+    "steal": "^1.7.0",
     "steal-qunit": "^1.0.0",
     "steal-tools": "^1.0.0",
     "testee": "^0.7.0"

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,16 @@ QUnit.test("can-import works", function(){
 	});
 });
 
+QUnit.test("error messages includes the source", function(){
+	stop();
+	loader["import"]("test/tests/oops.stache")
+	.then(null, function(err){
+		ok(/can-import/.test(err.message), "can-import code is in the message");
+		ok(/oops.stache/.test(err.stack), "the importing file is in the stack");
+		start();
+	});
+});
+
 QUnit.test("can-import is provided the filename", function(){
 	stop();
 	clone({

--- a/test/tests/oops.stache
+++ b/test/tests/oops.stache
@@ -1,0 +1,5 @@
+<can-import from="./file-missing" />
+
+<section class="app">
+	<div>...</div>
+</section>


### PR DESCRIPTION
This adds improved error messaging, taking advantage of config that can
be added to a module's metadata to show inline code examples of when
there is a 404.

<img width="640" alt="screen shot 2018-03-01 at 9 22 27 am" src="https://user-images.githubusercontent.com/361671/36849452-1ad096a4-1d32-11e8-8e78-e02321575180.png">