### PR TITLE
68 object assign polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     }
   },
   "dependencies": {
+    "can-assign": "^1.0.0",
     "can-stache": "^4.0.0",
     "can-stache-ast": "^1.0.0",
     "can-stache-bindings": "^4.0.0",

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -14,9 +14,10 @@ function template(imports, intermediate, filename){
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
 		"\treturn function(scope, options, nodeList){\n" +
-		"\t\tvar moduleOptions = Object.assign({}, options);\n" +
+		"\tvar assign = function (d, s) { for (var prop in s) { var desc = Object.getOwnPropertyDescriptor(d,prop); if(!desc || desc.writable !== false){ d[prop] = s[prop]; } } return d; };" +
+		"\t\tvar moduleOptions = assign({}, options);\n" +
 		"\t\tif(moduleOptions.helpers) {\n" +
-		"\t\t\tmoduleOptions.helpers = Object.assign({ module: module }, moduleOptions.helpers);\n" +
+		"\t\t\tmoduleOptions.helpers = assign({ module: module }, moduleOptions.helpers);\n" +
 		"\t\t} else {\n" +
 		"\t\t\tmoduleOptions.module = module;\n" +
 		"\t\t}\n" +

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -8,13 +8,12 @@ function template(imports, intermediate, filename){
 	imports = JSON.stringify(imports);
 	intermediate = JSON.stringify(intermediate);
 
-	return "define("+imports+",function(module, stache, mustacheCore){\n" +
+	return "define("+imports+",function(module, assign, stache, mustacheCore){ \n" +
 		(filename ?
 			"\tvar renderer = stache(" + JSON.stringify(filename) + ", " + intermediate + ");\n" :
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
 		"\treturn function(scope, options, nodeList){\n" +
-		"\tvar assign = function (d, s) { for (var prop in s) { var desc = Object.getOwnPropertyDescriptor(d,prop); if(!desc || desc.writable !== false){ d[prop] = s[prop]; } } return d; };" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
 		"\t\tif(moduleOptions.helpers) {\n" +
 		"\t\t\tmoduleOptions.helpers = assign({ module: module }, moduleOptions.helpers);\n" +
@@ -77,6 +76,7 @@ function translate(load) {
 
 		ast.imports.unshift("can-stache/src/mustache_core");
 		ast.imports.unshift("can-stache");
+		ast.imports.unshift("can-assign");
 		ast.imports.unshift("module");
 
 		return template(

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <title>steal-stache</title>
 <script src="../node_modules/steal/steal.js" main="steal-stache/test/test"></script>
 <div id="qunit-fixture"></div>

--- a/test/test.js
+++ b/test/test.js
@@ -127,7 +127,7 @@ QUnit.test("inline assign call works in IE11 (#81)", function(assert){
 			}
 		});
 
-		assert.equal(frag.firstChild.firstChild.nodeValue, "works");
+		assert.equal(frag.firstChild.firstChild.nodeValue, "works without Object.assign");
 		window.Object.assign = oldAssign
 		done();
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -114,12 +114,13 @@ QUnit.test("Can call helpers passed into the renderer", function(assert){
 	});
 });
 
-QUnit.test("inline assign call works in IE11 (#81)", function(assert){
+QUnit.test("pass can-assign for IE11 compatibility (#81)", function(assert){
 	var done = assert.async();
 	var oldAssign = window.Object.assign;
 	window.Object.assign = null;
 
-	loader["import"]("test/tests/helper.stache").then(function(renderer){
+	loader["import"]("test/tests/helper.stache")
+	.then(function(renderer){
 
 		var frag = renderer({}, {
 			test: function(){
@@ -127,8 +128,11 @@ QUnit.test("inline assign call works in IE11 (#81)", function(assert){
 			}
 		});
 
-		assert.equal(frag.firstChild.firstChild.nodeValue, "works without Object.assign");
 		window.Object.assign = oldAssign;
+		assert.equal(frag.firstChild.firstChild.nodeValue, "works without Object.assign");
 		done();
+	})
+	.catch(function (err) {
+		console.log(err);
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -113,3 +113,23 @@ QUnit.test("Can call helpers passed into the renderer", function(assert){
 		done();
 	});
 });
+
+QUnit.test("inline assign call works in IE11 (#81)", function(assert){
+	debugger
+	var done = assert.async();
+	var oldAssign = window.Object.assign
+	window.Object.assign = null
+
+	loader["import"]("test/tests/helper.stache").then(function(renderer){
+
+		var frag = renderer({}, {
+			test: function(){
+				return "works";
+			}
+		});
+
+		assert.equal(frag.firstChild.firstChild.nodeValue, "works");
+		window.Object.assign = oldAssign
+		done();
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -115,7 +115,6 @@ QUnit.test("Can call helpers passed into the renderer", function(assert){
 });
 
 QUnit.test("inline assign call works in IE11 (#81)", function(assert){
-	debugger
 	var done = assert.async();
 	var oldAssign = window.Object.assign
 	window.Object.assign = null
@@ -124,7 +123,7 @@ QUnit.test("inline assign call works in IE11 (#81)", function(assert){
 
 		var frag = renderer({}, {
 			test: function(){
-				return "works";
+				return "works without Object.assign";
 			}
 		});
 

--- a/test/test.js
+++ b/test/test.js
@@ -116,8 +116,8 @@ QUnit.test("Can call helpers passed into the renderer", function(assert){
 
 QUnit.test("inline assign call works in IE11 (#81)", function(assert){
 	var done = assert.async();
-	var oldAssign = window.Object.assign
-	window.Object.assign = null
+	var oldAssign = window.Object.assign;
+	window.Object.assign = null;
 
 	loader["import"]("test/tests/helper.stache").then(function(renderer){
 
@@ -128,7 +128,7 @@ QUnit.test("inline assign call works in IE11 (#81)", function(assert){
 		});
 
 		assert.equal(frag.firstChild.firstChild.nodeValue, "works without Object.assign");
-		window.Object.assign = oldAssign
+		window.Object.assign = oldAssign;
 		done();
 	});
 });


### PR DESCRIPTION
This adds `can-assign` to provide a built in `Object.assign` polyfill for IE11 compatibility.

Closes #68 