### PR TITLE
syncronous import via can-import tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "can-stache": "^4.0.0",
     "can-stache-ast": "^1.0.0",
     "can-stache-bindings": "^4.0.0",
-    "can-view-import": "^4.2.2",
+    "can-view-import": "canjs/can-view-import#major",
     "steal-config-utils": "^1.0.0"
   },
   "devDependencies": {

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -5,21 +5,30 @@ var loader = require("@loader");
 var addImportSpecifiers = require("steal-config-utils/import-specifiers").addImportSpecifiers;
 
 function template(imports, intermediate, filename){
+	var tagImportNames = JSON.stringify(imports.slice(5));
 	imports = JSON.stringify(imports);
 	intermediate = JSON.stringify(intermediate);
 
-	return "define("+imports+",function(module, assign, stache, mustacheCore){ \n" +
+	return "define("+imports+",function(module, assign, stache, mustacheCore, canViewImport, canStacheBindings){ \n" +
 		(filename ?
 			"\tvar renderer = stache(" + JSON.stringify(filename) + ", " + intermediate + ");\n" :
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
+    "\tvar tagImports = arguments.slice(6);\n"
 		"\treturn function(scope, options, nodeList){\n" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
+    "\t\tvar tagImportMap = " + tagImportNames + ".reduce((map, name, index) => {\n" +
+    "\t\t\tmap[name] = tagImports[index];\n" +
+    "\t\t\treturn map;\n" +
+    "\t\t}, {});\n" +
+    "\n"+
 		"\t\tif(moduleOptions.helpers) {\n" +
-		"\t\t\tmoduleOptions.helpers = assign({ module: module }, moduleOptions.helpers);\n" +
+		"\t\t\tmoduleOptions.helpers = assign({ module: module, tagImportMap: tagImportMap }, moduleOptions.helpers);\n" +
 		"\t\t} else {\n" +
 		"\t\t\tmoduleOptions.module = module;\n" +
+		"\t\t\tmoduleOptions.tagImportMap = tagImportMap;\n" +
 		"\t\t}\n" +
+		"\n" +
 		"\t\treturn renderer(scope, moduleOptions, nodeList);\n" +
 		"\t};\n" +
 	"});";

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -5,7 +5,7 @@ var loader = require("@loader");
 var addImportSpecifiers = require("steal-config-utils/import-specifiers").addImportSpecifiers;
 
 function template(imports, intermediate, filename){
-	var tagImportNames = JSON.stringify(imports.slice(5));
+	var tagImportNames = JSON.stringify(imports.slice(6));
 	imports = JSON.stringify(imports);
 	intermediate = JSON.stringify(intermediate);
 
@@ -14,7 +14,7 @@ function template(imports, intermediate, filename){
 			"\tvar renderer = stache(" + JSON.stringify(filename) + ", " + intermediate + ");\n" :
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
-    "\tvar tagImports = arguments.slice(6);\n"
+    "\tvar tagImports = Array.prototype.slice.call(arguments, 6);\n" +
 		"\treturn function(scope, options, nodeList){\n" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
     "\t\tvar tagImportMap = " + tagImportNames + ".reduce((map, name, index) => {\n" +

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -14,14 +14,14 @@ function template(imports, intermediate, filename){
 			"\tvar renderer = stache(" + JSON.stringify(filename) + ", " + intermediate + ");\n" :
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
-    "\tvar tagImports = Array.prototype.slice.call(arguments, 6);\n" +
+		"\tvar tagImports = Array.prototype.slice.call(arguments, 6);\n" +
 		"\treturn function(scope, options, nodeList){\n" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
-    "\t\tvar tagImportMap = " + tagImportNames + ".reduce((map, name, index) => {\n" +
-    "\t\t\tmap[name] = tagImports[index];\n" +
-    "\t\t\treturn map;\n" +
-    "\t\t}, {});\n" +
-    "\n"+
+		"\t\tvar tagImportMap = " + tagImportNames + ".reduce((map, name, index) => {\n" +
+		"\t\t\tmap[name] = tagImports[index];\n" +
+		"\t\t\treturn map;\n" +
+		"\t\t}, {});\n" +
+		"\n"+
 		"\t\tif(moduleOptions.helpers) {\n" +
 		"\t\t\tmoduleOptions.helpers = assign({ module: module, tagImportMap: tagImportMap }, moduleOptions.helpers);\n" +
 		"\t\t} else {\n" +

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -5,16 +5,16 @@ var loader = require("@loader");
 var addImportSpecifiers = require("steal-config-utils/import-specifiers").addImportSpecifiers;
 
 function template(imports, intermediate, filename){
-	var tagImportNames = JSON.stringify(imports.slice(6));
+	var tagImportNames = JSON.stringify(imports.slice(7));
 	imports = JSON.stringify(imports);
 	intermediate = JSON.stringify(intermediate);
 
-	return "define("+imports+",function(module, assign, stache, mustacheCore, canViewImport, canStacheBindings){ \n" +
+	return "define("+imports+",function(module, assign, stache, mustacheCore, Scope, canViewImport, canStacheBindings){ \n" +
 		(filename ?
 			"\tvar renderer = stache(" + JSON.stringify(filename) + ", " + intermediate + ");\n" :
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
-		"\tvar tagImports = Array.prototype.slice.call(arguments, 6);\n" +
+		"\tvar tagImports = Array.prototype.slice.call(arguments, 7);\n" +
 		"\treturn function(scope, options, nodeList){\n" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
 		"\t\tvar tagImportMap = " + tagImportNames + ".reduce(function(map, name, index) {\n" +
@@ -22,12 +22,13 @@ function template(imports, intermediate, filename){
 		"\t\t\treturn map;\n" +
 		"\t\t}, {});\n" +
 		"\n"+
-		"\t\tif(moduleOptions.helpers) {\n" +
-		"\t\t\tmoduleOptions.helpers = assign({ module: module, tagImportMap: tagImportMap }, moduleOptions.helpers);\n" +
-		"\t\t} else {\n" +
-		"\t\t\tmoduleOptions.module = module;\n" +
-		"\t\t\tmoduleOptions.tagImportMap = tagImportMap;\n" +
+		"\t\tif (!(scope instanceof Scope)) { scope = new Scope(scope); }\n" +
+		"\t\tvar variableScope = scope.getScope(function(s) { return s._meta.variable === true });\n" +
+		"\t\tif (!variableScope) {\n" +
+		"\t\t\tscope = scope.addLetContext();\n" +
+		"\t\t\tvariableScope = scope;\n" +
 		"\t\t}\n" +
+		"\t\tassign(variableScope._context, { module: module, tagImportMap: tagImportMap });\n" +
 		"\n" +
 		"\t\treturn renderer(scope, moduleOptions, nodeList);\n" +
 		"\t};\n" +
@@ -83,6 +84,7 @@ function translate(load) {
 			ast.imports, imports
 		);
 
+		ast.imports.unshift("can-view-scope");
 		ast.imports.unshift("can-stache/src/mustache_core");
 		ast.imports.unshift("can-stache");
 		ast.imports.unshift("can-assign");

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -17,7 +17,7 @@ function template(imports, intermediate, filename){
 		"\tvar tagImports = Array.prototype.slice.call(arguments, 6);\n" +
 		"\treturn function(scope, options, nodeList){\n" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
-		"\t\tvar tagImportMap = " + tagImportNames + ".reduce((map, name, index) => {\n" +
+		"\t\tvar tagImportMap = " + tagImportNames + ".reduce(function(map, name, index) {\n" +
 		"\t\t\tmap[name] = tagImports[index];\n" +
 		"\t\t\treturn map;\n" +
 		"\t\t}, {});\n" +

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,19 @@ QUnit.test("can-import works", function(assert) {
 	});
 });
 
+QUnit.test("`can-import`ed modules are available synchronously", function(assert){
+	var done = assert.async();
+
+	loader["import"]("test/tests/baz.stache").then(function(template) {
+		template({
+			test: function(value) {
+				assert.equal(value, "works", "Initial render occurs with can-import already completed.");
+				done();
+			}
+		});
+	});
+});
+
 QUnit.test("error messages includes the source", function(assert) {
 	var done = assert.async();
 

--- a/test/test.js
+++ b/test/test.js
@@ -38,13 +38,15 @@ QUnit.test("can-import works", function(assert) {
 	});
 });
 
-QUnit.test("`can-import`ed modules are available synchronously", function(assert){
+QUnit.test("`can-import`ed modules are available synchronously, and in a LetContext", function(assert){
 	var done = assert.async();
 
 	loader["import"]("test/tests/baz.stache").then(function(template) {
 		template({
-			test: function(value) {
+			test: function(value, scope) {
 				assert.equal(value, "works", "Initial render occurs with can-import already completed.");
+				assert.ok(scope._meta.variable, "Bottom scope is a LetContext.");
+				assert.equal(scope._context._data.bar, "works", "`bar` variable is in the LetContext.");
 				done();
 			}
 		});

--- a/test/test.js
+++ b/test/test.js
@@ -86,7 +86,7 @@ QUnit.test("module info is set when 'options' is missing", function(assert) {
 	var done = assert.async(2);
 
 	tag("fake-import", function fakeImport(el, tagData) {
-		var m = tagData.scope.get("scope.helpers.module");
+		var m = tagData.scope.get("module");
 		assert.ok(m.id.includes("test/module-meta/index"));
 		done();
 	});
@@ -101,7 +101,7 @@ QUnit.test("module info is set when 'options.helpers' exists", function(assert) 
 	var done = assert.async(2);
 
 	tag("fake-import", function fakeImport(el, tagData) {
-		var m = tagData.scope.get("scope.helpers.module");
+		var m = tagData.scope.get("module");
 		assert.ok(m.id.includes("test/module-meta/index"));
 		done();
 	});

--- a/test/tests/baz.stache
+++ b/test/tests/baz.stache
@@ -1,0 +1,2 @@
+<can-import from='test/tests/bar' export:to="scope.vars.bar" />
+{{ test(scope.vars.bar) }}

--- a/test/tests/baz.stache
+++ b/test/tests/baz.stache
@@ -1,2 +1,2 @@
-<can-import from='test/tests/bar' export:to="scope.vars.bar" />
-{{ test(scope.vars.bar) }}
+<can-import from='test/tests/bar' module:to="bar" />
+{{ test(bar, scope) }}


### PR DESCRIPTION
Passes `can-import`ed modules to stache in helpers scope. 
Add test to check if can-import tags immediately have `export` property on view model when loaded by steal-stache.

Part of the resolution of canjs/can-view-import#111.

Test on this will fail until changes in canjs/can-view-import#124 are available.