### PR TITLE
Revert "syncronous import via can-import tags"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "can-stache": "^4.0.0",
     "can-stache-ast": "^1.0.0",
     "can-stache-bindings": "^4.0.0",
-    "can-view-import": "canjs/can-view-import#major",
+    "can-view-import": "^4.2.2",
     "steal-config-utils": "^1.0.0"
   },
   "devDependencies": {

--- a/steal-stache.js
+++ b/steal-stache.js
@@ -5,31 +5,21 @@ var loader = require("@loader");
 var addImportSpecifiers = require("steal-config-utils/import-specifiers").addImportSpecifiers;
 
 function template(imports, intermediate, filename){
-	var tagImportNames = JSON.stringify(imports.slice(7));
 	imports = JSON.stringify(imports);
 	intermediate = JSON.stringify(intermediate);
 
-	return "define("+imports+",function(module, assign, stache, mustacheCore, Scope, canViewImport, canStacheBindings){ \n" +
+	return "define("+imports+",function(module, assign, stache, mustacheCore){ \n" +
 		(filename ?
 			"\tvar renderer = stache(" + JSON.stringify(filename) + ", " + intermediate + ");\n" :
 			"\tvar renderer = stache(" + intermediate + ");\n"
 		) +
-		"\tvar tagImports = Array.prototype.slice.call(arguments, 7);\n" +
 		"\treturn function(scope, options, nodeList){\n" +
 		"\t\tvar moduleOptions = assign({}, options);\n" +
-		"\t\tvar tagImportMap = " + tagImportNames + ".reduce(function(map, name, index) {\n" +
-		"\t\t\tmap[name] = tagImports[index];\n" +
-		"\t\t\treturn map;\n" +
-		"\t\t}, {});\n" +
-		"\n"+
-		"\t\tif (!(scope instanceof Scope)) { scope = new Scope(scope); }\n" +
-		"\t\tvar variableScope = scope.getScope(function(s) { return s._meta.variable === true });\n" +
-		"\t\tif (!variableScope) {\n" +
-		"\t\t\tscope = scope.addLetContext();\n" +
-		"\t\t\tvariableScope = scope;\n" +
+		"\t\tif(moduleOptions.helpers) {\n" +
+		"\t\t\tmoduleOptions.helpers = assign({ module: module }, moduleOptions.helpers);\n" +
+		"\t\t} else {\n" +
+		"\t\t\tmoduleOptions.module = module;\n" +
 		"\t\t}\n" +
-		"\t\tassign(variableScope._context, { module: module, tagImportMap: tagImportMap });\n" +
-		"\n" +
 		"\t\treturn renderer(scope, moduleOptions, nodeList);\n" +
 		"\t};\n" +
 	"});";
@@ -84,7 +74,6 @@ function translate(load) {
 			ast.imports, imports
 		);
 
-		ast.imports.unshift("can-view-scope");
 		ast.imports.unshift("can-stache/src/mustache_core");
 		ast.imports.unshift("can-stache");
 		ast.imports.unshift("can-assign");

--- a/test/test.js
+++ b/test/test.js
@@ -38,21 +38,6 @@ QUnit.test("can-import works", function(assert) {
 	});
 });
 
-QUnit.test("`can-import`ed modules are available synchronously, and in a LetContext", function(assert){
-	var done = assert.async();
-
-	loader["import"]("test/tests/baz.stache").then(function(template) {
-		template({
-			test: function(value, scope) {
-				assert.equal(value, "works", "Initial render occurs with can-import already completed.");
-				assert.ok(scope._meta.variable, "Bottom scope is a LetContext.");
-				assert.equal(scope._context._data.bar, "works", "`bar` variable is in the LetContext.");
-				done();
-			}
-		});
-	});
-});
-
 QUnit.test("error messages includes the source", function(assert) {
 	var done = assert.async();
 
@@ -88,7 +73,7 @@ QUnit.test("module info is set when 'options' is missing", function(assert) {
 	var done = assert.async(2);
 
 	tag("fake-import", function fakeImport(el, tagData) {
-		var m = tagData.scope.get("module");
+		var m = tagData.scope.get("scope.helpers.module");
 		assert.ok(m.id.includes("test/module-meta/index"));
 		done();
 	});
@@ -103,7 +88,7 @@ QUnit.test("module info is set when 'options.helpers' exists", function(assert) 
 	var done = assert.async(2);
 
 	tag("fake-import", function fakeImport(el, tagData) {
-		var m = tagData.scope.get("module");
+		var m = tagData.scope.get("scope.helpers.module");
 		assert.ok(m.id.includes("test/module-meta/index"));
 		done();
 	});

--- a/test/tests/baz.stache
+++ b/test/tests/baz.stache
@@ -1,2 +1,0 @@
-<can-import from='test/tests/bar' module:to="bar" />
-{{ test(bar, scope) }}


### PR DESCRIPTION
Reverts canjs/steal-stache#83. Intended for #major branch.